### PR TITLE
XEP-0045: Attempt to shuffle text about GC 1.0 out of view

### DIFF
--- a/xep-0045.xml
+++ b/xep-0045.xml
@@ -1397,15 +1397,22 @@
   </section2>
 
   <section2 topic='Entering a Room' anchor='enter'>
-    <section3 topic='Groupchat 1.0 Protocol' anchor='enter-gc'>
-      <p>In order to participate in the discussions held in a multi-user chat room, a user MUST first become an occupant by entering the room. In the old groupchat 1.0 protocol, this was done by sending presence with no 'type' attribute to &OCCUPANTJID;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
-      <example caption='User Seeks to Enter a Room (groupchat 1.0)'><![CDATA[
+    <section3 topic='Basic MUC Protocol' anchor='enter-muc'>
+      <p>In order to participate in the discussions held in a multi-user chat room, a user MUST first become an occupant by entering the room. </p>
+
+      <p>MUC clients MUST signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
+      <example caption='User Seeks to Enter a Room (Multi-User Chat)'><![CDATA[
 <presence
     from='hag66@shakespeare.lit/pda'
-    id='ng91xs69'
-    to='coven@chat.shakespeare.lit/thirdwitch'/>
+    id='n13mt3l'
+    to='coven@chat.shakespeare.lit/thirdwitch'>
+  <x xmlns='http://jabber.org/protocol/muc'/>
+</presence>
 ]]></example>
+
       <p>In this example, a user with a full JID of "hag66@shakespeare.lit/pda" has requested to enter the room "coven" on the "chat.shakespeare.lit" chat service with a room nickname of "thirdwitch".</p>
+      <p>Note: The presence stanza used to join a room MUST NOT possess a 'type' attribute, i.e., it must be available presence. For further discussion, see the <link url='#bizrules-presence'>Presence</link> business rules.</p>
+
       <p>If the user does not specify a room nickname (note the bare JID on the 'from' address in the following example), the service MUST return a &badjid; error:</p>
       <example caption='No Nickname Specified'><![CDATA[
 <presence
@@ -1416,19 +1423,6 @@
   <error by='coven@chat.shakespeare.lit' type='modify'>
     <jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
   </error>
-</presence>
-]]></example>
-      <p>Note: The presence stanza used to join a room MUST NOT possess a 'type' attribute, i.e., it must be available presence. For further discussion, see the <link url='#bizrules-presence'>Presence</link> business rules.</p>
-    </section3>
-
-    <section3 topic='Basic MUC Protocol' anchor='enter-muc'>
-      <p>Compliant multi-user chat services MUST accept the foregoing as a request to enter a room from any client that knows either the groupchat 1.0 protocol or the multi-user chat (MUC) protocol; however, MUC clients SHOULD signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
-      <example caption='User Seeks to Enter a Room (Multi-User Chat)'><![CDATA[
-<presence
-    from='hag66@shakespeare.lit/pda'
-    id='n13mt3l'
-    to='coven@chat.shakespeare.lit/thirdwitch'>
-  <x xmlns='http://jabber.org/protocol/muc'/>
 </presence>
 ]]></example>
       <p>Before attempting to enter the room, a MUC-compliant client SHOULD first discover its reserved room nickname (if any) by following the protocol defined in the <link url='#reservednick'>Discovering Reserved Room Nickname</link> section of this document.</p>
@@ -1903,6 +1897,15 @@
         </tr>
       </table>
     </section3>
+    <section3 topic='Groupchat 1.0 Protocol' anchor='enter-gc'>
+      <p>In the old groupchat 1.0 protocol, this was done by sending presence with no 'type' attribute to &OCCUPANTJID;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
+      <example caption='User Seeks to Enter a Room (groupchat 1.0)'><![CDATA[
+<presence
+    from='hag66@shakespeare.lit/pda'
+    id='ng91xs69'
+    to='coven@chat.shakespeare.lit/thirdwitch'/>
+]]></example>
+</section3>
 
   </section2>
 


### PR DESCRIPTION
I think this moves most of the GC 1.0 stuff away from the beginning of the section. So the first thing anyone sees isn't the GC 1.0 example.